### PR TITLE
add request handler

### DIFF
--- a/c3po/server.py
+++ b/c3po/server.py
@@ -39,15 +39,23 @@ class Server(object):
         self.port = port
         self.debug = debug
 
+    def __repr__(self):
+        return 'C3PO Server'
+
     def register(self, stub):
         self.stubs[stub.name] = stub
+
+    def request_handler(self, request):
+        pass
 
     def run(self, debug=False):
         app = tornado.web.Application([
             ('/service/([^/]+)/call/([^/]+)',
-             ServiceHandler, dict(stubs=self.stubs, debug=debug)),
+             ServiceHandler, dict(debug=debug,
+                                  server=self)),
             ('/',
-             HelloHandler, dict(stubs=self.stubs, debug=debug))
+             HelloHandler, dict(debug=debug,
+                                server=self))
         ], debug=debug)
 
         app.listen(self.port)

--- a/examples/server.py
+++ b/examples/server.py
@@ -22,6 +22,12 @@ stub.server_pb2_module_path = (CURRENT_DIR + '/grpc/server_pb2.py')
 
 app.register(stub)
 
+def handle_header(request):
+    metadata = ()
+    return metadata
+
+app.request_handler = handle_header
+
 try:
     print('running server on 0.0.0.0:8888')
     app.run(debug=True)


### PR DESCRIPTION
If client want to send us specific header like `Authorization`, we don't
want to parse all the HEADER to gRPC Metadata.

So this method could help use to translate request to metadata we want.

```python
app.register(stub)

def handle_header(request):
    metadata = ()
        return metadata

```